### PR TITLE
tick checkboxes of completed todos on load

### DIFF
--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -12,11 +12,11 @@ export class TodoItem extends Component {
   }
 
   render() {
-    const { id, title } = this.props.todo;
+    const { id, title, completed } = this.props.todo;
     return (
       <div style={this.getStyle()}>
         <p>
-          <input type="checkbox" onChange={this.props.markComplete.bind(this, id)} /> {' '}
+          <input checked={completed} type="checkbox" onChange={this.props.markComplete.bind(this, id)} /> {' '}
           { title }
           <button onClick={this.props.delTodo.bind(this, id)} style={btnStyle}>x</button>
         </p>


### PR DESCRIPTION
When the page loads I observed that all the checkboxes are unchecked, I added a fix for that by setting the `checked = {completed}` on the TodoItems. 

BTW @bradtraversy big fan! Thanks a lot for all the content 😄 